### PR TITLE
Improved regex for command detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn message_handler(ctx: Context, msg: Message) {
     }
 
     lazy_static! {
-        static ref PATTERN: Regex = Regex::new("^(?:(?:!!!+)|(?:;+)|(?:\\.\\.\\.+)).+").unwrap();
+        static ref PATTERN: Regex = Regex::new("^(!{3,}|;{3,}|\.{3,})[-\w\s]+.+").unwrap();
     }
 
     if msg.is_private() || msg.author.bot {


### PR DESCRIPTION
Regex works in theory but it might fail with some special cases which I didn't take into consideration, someone please peer check the regex string.